### PR TITLE
WindowLayout abstraction

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,6 @@
     - Route Noria mines
 
 * Terminal improvements
-    - Move WindowLayout into abstract class with exposed methods to abstract away all curses code from TAS
     - Experiment more with Textual/Rich
 * Write a sequence capture script that reads the memory and saves it, but doesn't control the game. Could possibly be used to "record" maps.
 

--- a/engine/seq.py
+++ b/engine/seq.py
@@ -3,7 +3,8 @@ import logging
 import time
 import datetime
 from typing import Any, Callable, List
-from term.curses import WindowLayout
+from term.window import WindowLayout
+from engine.mathlib import Vec2
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +243,7 @@ class SequencerEngine(object):
         duration = datetime.datetime.utcfromtimestamp(elapsed)
         timestamp = f"{duration.strftime('%H:%M:%S')}.{int(duration.strftime('%f')) // 1000:03d}"
         pause_str = " == PAUSED ==" if self.paused else ""
-        self.window.main.addstr(0, 0, f"[{timestamp}]{pause_str}")
+        self.window.main.addstr(Vec2(0, 0), f"[{timestamp}]{pause_str}")
 
     def _render(self) -> None:
         # Clear display windows
@@ -250,7 +251,7 @@ class SequencerEngine(object):
 
         # Render timer and gamestate tree
         self._print_timer()
-        self.window.main.addstr(1, 0, f"Gamestate:\n  {self.root}")
+        self.window.main.addstr(Vec2(0, 1), f"Gamestate:\n  {self.root}")
         # Render the current gamestate
         self.root.render(
             window=self.window, blackboard=self.blackboard

--- a/evo1/TAS.py
+++ b/evo1/TAS.py
@@ -1,6 +1,5 @@
 # Libraries and Core Files
 import contextlib
-import curses
 import logging
 
 import memory.core as core

--- a/evo1/TAS.py
+++ b/evo1/TAS.py
@@ -4,11 +4,12 @@ import curses
 import logging
 
 import memory.core as core
+from engine.mathlib import Vec2
 from engine.seq import SeqList, SeqOptional, SequencerEngine
 from evo1.checkpoints import Checkpoints
 from evo1.memory import load_memory, load_zelda_memory
 from evo1.seq import Edel1, Evoland1StartGame, OverworldToMeadow, MeadowFight, PapurikaVillage, OverworldToCavern, CrystalCavern, Edel2, OverworldToNoria, NoriaMines, OverworldToAogai
-from term.curses import WindowLayout
+from term.window import WindowLayout
 from evo1.observer import SeqObserver2D
 
 
@@ -31,9 +32,9 @@ def observer(window: WindowLayout):
         root=observer,
     )
 
-    window.main.clear()
-    window.stats.clear()
-    curses.doupdate()
+    window.main.erase()
+    window.stats.erase()
+    window.update()
 
     while engine.active():
         engine.run()
@@ -44,14 +45,14 @@ def observer(window: WindowLayout):
 def perform_TAS(window: WindowLayout):
 
     # Print loading
-    window.main.clear()
-    window.stats.clear()
+    window.main.erase()
+    window.stats.erase()
 
     text = "Preparing TAS"
-    maxy, maxx = window.main.getmaxyx()
+    size = window.main.size
     text_len = len(text)
-    x_off = int(maxx / 2 - text_len / 2)
-    window.main.addstr(int(maxy / 2), x_off, text)
+    x_off = int(size.x / 2 - text_len / 2)
+    window.main.addstr(Vec2(x_off, int(size.y / 2)), text)
     window.update()
 
     logger.info("Evoland1 TAS selected")
@@ -128,9 +129,9 @@ def perform_TAS(window: WindowLayout):
     )
 
     # Clear screen
-    window.main.clear()
-    window.stats.clear()
-    curses.doupdate()
+    window.main.erase()
+    window.stats.erase()
+    window.update()
 
     # Run sequence
     while engine.active():

--- a/evo1/atb.py
+++ b/evo1/atb.py
@@ -7,7 +7,7 @@ from evo1.move2d import SeqMove2D, move_to
 from evo1.memory import get_memory, get_zelda_memory, MapID, BattleMemory, BattleEntity
 from memory.rng import EvolandRNG
 from enum import Enum, auto
-from term.curses import WindowLayout
+from term.window import WindowLayout
 
 from typing import List
 
@@ -182,12 +182,12 @@ class SeqATBCombat(SeqBase):
         if not self.active:
             return
         window.stats.erase()
-        window.write_stats_centered(line=1, text="Evoland 1 TAS")
-        window.write_stats_centered(line=2, text="ATB Combat")
+        window.stats.write_centered(line=1, text="Evoland 1 TAS")
+        window.stats.write_centered(line=2, text="ATB Combat")
 
-        window.stats.addstr(4, 1, "Party:")
+        window.stats.addstr(Vec2(1, 4), "Party:")
         self._print_group(window=window, group=self.mem.allies, y_offset=5)
-        window.stats.addstr(8, 1, "Enemies:")
+        window.stats.addstr(Vec2(1, 8), "Enemies:")
         self._print_group(window=window, group=self.mem.enemies, y_offset=9)
 
         # TODO: Hit/Damage prediction
@@ -195,15 +195,15 @@ class SeqATBCombat(SeqBase):
         if not self.mem.ended:
             # TODO: Damage prediction for Kaeris
             dmg = self.predict_damage(self.mem.allies[0], self.mem.enemies[0])
-            window.stats.addstr(13, 1, "Damage prediction:")
-            window.stats.addstr(14, 2, f"Clink: {dmg}")
+            window.stats.addstr(Vec2(1, 13), "Damage prediction:")
+            window.stats.addstr(Vec2(2, 14), f"Clink: {dmg}")
 
         # TODO: map representation
 
     def _print_group(self, window: WindowLayout, group: List[BattleEntity], y_offset: int) -> None:
         for i, entity in enumerate(group):
             y_pos = y_offset + i
-            window.stats.addstr(y_pos, 2, f"{entity.cur_hp}/{entity.max_hp} [{entity.turn_gauge:.02f}]")
+            window.stats.addstr(Vec2(2, y_pos), f"{entity.cur_hp}/{entity.max_hp} [{entity.turn_gauge:.02f}]")
 
     def __repr__(self) -> str:
         if self.active:
@@ -290,8 +290,8 @@ class SeqATBmove2D(SeqMove2D):
         if self.next_enc:
             mem = get_zelda_memory()
             enc_timer = mem.player.encounter_timer
-            window.stats.addstr(12, 1, f" Next enc ({enc_timer:.3f}):")
-            window.stats.addstr(13, 1, f"  {self.next_enc.name}")
+            window.stats.addstr(Vec2(1, 12), f" Next enc ({enc_timer:.3f}):")
+            window.stats.addstr(Vec2(1, 13), f"  {self.next_enc.name}")
 
     def __repr__(self) -> str:
         # Check for active battle

--- a/evo1/knights.py
+++ b/evo1/knights.py
@@ -7,7 +7,7 @@ from engine.mathlib import Facing, Vec2, Box2, get_box_with_size, grow_box, get_
 from evo1.memory import GameEntity2D, ZeldaMemory, get_zelda_memory
 from evo1.move2d import SeqSection2D, move_to
 import evo1.control
-from term.curses import WindowLayout
+from term.window import WindowLayout, SubWindow
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +189,7 @@ class SeqKnight2D(SeqSection2D):
         self._print_arena(map_win=window.map, blackboard=blackboard)
         self._print_actors(map_win=window.map, blackboard=blackboard)
 
-    def _print_arena(self, map_win, blackboard: dict) -> None:
+    def _print_arena(self, map_win: SubWindow, blackboard: dict) -> None:
         # Draw a box representing the arena on the map. The representation is one tile
         # bigger so no entities inside the actual arena are overwritten.
         mem = get_zelda_memory()

--- a/evo1/move2d.py
+++ b/evo1/move2d.py
@@ -6,7 +6,7 @@ from typing import List
 import evo1.control
 from engine.seq import SeqBase, SeqDelay
 from evo1.memory import GameFeatures, GameEntity2D, get_zelda_memory, get_memory, MapID
-from term.curses import WindowLayout
+from term.window import WindowLayout, SubWindow
 from engine.mathlib import Facing, facing_str, Vec2, is_close, dist, get_angle
 from evo1.maps import CurrentTilemap
 
@@ -209,37 +209,37 @@ class SeqSection2D(SeqBase):
     _map_start_y = 2
 
     def _print_player_stats(self, window: WindowLayout, blackboard: dict) -> None:
-        window.write_stats_centered(line=1, text="Evoland 1 TAS")
-        window.write_stats_centered(line=2, text="2D section")
+        window.stats.write_centered(line=1, text="Evoland 1 TAS")
+        window.stats.write_centered(line=2, text="2D section")
         mem = get_zelda_memory()
         pos = mem.player.pos
-        window.stats.addstr(4, 1, f" Player X: {pos.x:.3f}")
-        window.stats.addstr(5, 1, f" Player Y: {pos.y:.3f}")
-        window.stats.addstr(6, 1, f"  Facing: {facing_str(mem.player.facing)}")
+        window.stats.addstr(Vec2(1, 4), f" Player X: {pos.x:.3f}")
+        window.stats.addstr(Vec2(1, 5), f" Player Y: {pos.y:.3f}")
+        window.stats.addstr(Vec2(1, 6), f"  Facing: {facing_str(mem.player.facing)}")
         # Draw the player at the center for reference
         self._print_ch_in_map(map_win=window.map, pos=Vec2(0, 0), ch="@")
 
     # (0,0) is at center of map. Y-axis increases going down the screen.
-    def _print_ch_in_map(self, map_win, pos: Vec2, ch: str):
-        maxy, maxx = map_win.getmaxyx()
-        centerx, centery = maxx / 2, self._map_start_y + (maxy - self._map_start_y) / 2
+    def _print_ch_in_map(self, map_win: SubWindow, pos: Vec2, ch: str):
+        size = map_win.size
+        centerx, centery = size.x / 2, self._map_start_y + (size.y - self._map_start_y) / 2
         draw_x, draw_y = int(centerx + pos.x), int(centery + pos.y)
         with contextlib.suppress(Exception):
-            if draw_x in range(maxx) and draw_y in range(self._map_start_y, maxy):
-                map_win.addch(draw_y, draw_x, ch)
+            if draw_x in range(size.x) and draw_y in range(self._map_start_y, size.y):
+                map_win.addch(Vec2(draw_x, draw_y), ch)
 
-    def _print_env(self, map_win, blackboard: dict) -> None:
-        maxy, maxx = map_win.getmaxyx()
+    def _print_env(self, map_win: SubWindow, blackboard: dict) -> None:
+        size = map_win.size
         # Fill box with .
-        for y in range(self._map_start_y, maxy):
-            map_win.hline(y, 0, " ", maxx)
+        for y in range(self._map_start_y, size.y):
+            map_win.hline(Vec2(0, y), " ", size.x)
 
     def _print_map(self, window: WindowLayout, blackboard: dict) -> None:
         if tilemap := CurrentTilemap():
             mem = get_zelda_memory()
             center = mem.player.pos
             # Render map
-            window.write_map_centered(0, tilemap.name)
+            window.map.write_centered(0, tilemap.name)
             for i, line in enumerate(tilemap.tiles):
                 y_pos = i + tilemap.origin.y
                 for j, tile in enumerate(line):
@@ -247,7 +247,7 @@ class SeqSection2D(SeqBase):
                     draw_pos = Vec2(x_pos, y_pos) - center
                     self._print_ch_in_map(window.map, pos=draw_pos, ch=tile)
 
-    def _print_actors(self, map_win, blackboard: dict) -> None:
+    def _print_actors(self, map_win: SubWindow, blackboard: dict) -> None:
         mem = get_zelda_memory()
         center = mem.player.pos
 
@@ -322,11 +322,11 @@ class SeqMove2D(SeqSection2D):
 
         target = self.coords[self.step]
         step = self.step + 1
-        window.write_stats_centered(
+        window.stats.write_centered(
             line=8, text=f"Moving to [{step}/{num_coords}]"
         )
-        window.stats.addstr(9, 1, f" Target X: {target.x:.3f}")
-        window.stats.addstr(10, 1, f" Target Y: {target.y:.3f}")
+        window.stats.addstr(Vec2(1, 9), f" Target X: {target.x:.3f}")
+        window.stats.addstr(Vec2(1, 10), f" Target Y: {target.y:.3f}")
 
         # Draw target in relation to player
         mem = get_zelda_memory()

--- a/evo1/observer.py
+++ b/evo1/observer.py
@@ -4,7 +4,7 @@ import logging
 from evo1.memory import get_zelda_memory
 from engine.mathlib import Vec2, dist
 from evo1.move2d import SeqSection2D
-from term.curses import WindowLayout
+from term.window import WindowLayout
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,6 @@ class SeqObserver2D(SeqSection2D):
         mem = get_zelda_memory()
 
         if target := mem.player.target:
-            window.stats.addstr(9, 1, f" Target X: {target.x:.3f}")
-            window.stats.addstr(10, 1, f" Target Y: {target.y:.3f}")
+            window.stats.addstr(Vec2(1, 9), f" Target X: {target.x:.3f}")
+            window.stats.addstr(Vec2(1, 10), f" Target Y: {target.y:.3f}")
 

--- a/evo1/seq/overworld.py
+++ b/evo1/seq/overworld.py
@@ -6,7 +6,7 @@ from evo1.move2d import SeqZoneTransition, SeqGrabChest, SeqMove2D, move_to
 from evo1.memory import MapID, get_zelda_memory, get_memory
 from evo1.maps import GetAStar
 from typing import List, Optional
-from term.curses import WindowLayout
+from term.window import WindowLayout
 import logging
 
 _overworld_astar = GetAStar(MapID.OVERWORLD)
@@ -108,7 +108,7 @@ class OverworldGliFarm(SeqATBmove2D):
     def render(self, window: WindowLayout, blackboard: dict) -> None:
         super().render(window, blackboard)
         if self.can_manip and self.manipulated_enc:
-            window.stats.addstr(15, 1, f"  Manip: {self.manipulated_enc.name}")
+            window.stats.addstr(Vec2(1, 15), f"  Manip: {self.manipulated_enc.name}")
 
 class OverworldToMeadow(SeqList):
     def __init__(self):

--- a/evo2/TAS.py
+++ b/evo2/TAS.py
@@ -4,7 +4,7 @@ import logging
 import evo2.control as control
 import evo2.memory as memory
 import memory.core as core
-from term.curses import WindowLayout
+from term.window import WindowLayout
 
 logger = logging.getLogger(__name__)
 ctrl = control.handle()

--- a/term/curses.py
+++ b/term/curses.py
@@ -1,5 +1,7 @@
 import curses
 from curses import wrapper as curses_wrapper
+from term.window import SubWindow, WindowLayout
+from engine.mathlib import Vec2, Box2
 
 from term.log_init import initialize_logging
 
@@ -8,20 +10,64 @@ def entry_point(config_data: dict, func):
     curses_wrapper(setup_curses, config_data, func)
 
 
-class WindowLayout:
+class CursesWindow(SubWindow):
+    def __init__(self, bounds: Box2, auto_scroll: bool = False) -> None:
+        self.window = curses.newwin(bounds.h, bounds.w, bounds.pos.y, bounds.pos.x)
+        self.window.refresh()
+        if auto_scroll:
+            self.window.scrollok(True)
+            self.window.idlok(True)
+            self.window.leaveok(True)
+        super().__init__()
+
+    @property
+    def size(self) -> Vec2:
+        y, x = self.window.getmaxyx()
+        return Vec2(x, y)
+
+    def getch(self) -> str:
+        return self.window.getch()
+
+    def addch(self, pos: Vec2, text: str) -> None:
+        self.window.addch(pos.y, pos.x, text)
+
+    def addstr(self, pos: Vec2, text: str) -> None:
+        self.window.addstr(pos.y, pos.x, text)
+
+    def hline(self, pos: Vec2, character: str, length: int) -> None:
+        self.window.hline(pos.y, pos.x, character, length)
+
+    def write_centered(self, line: int, text: str) -> None:
+        _, maxx = self.window.getmaxyx()
+        text_len = len(text)
+        x_off = int(maxx / 2 - text_len / 2)
+        self.window.addstr(line, x_off, text)
+
+    def erase(self) -> None:
+        self.window.erase()
+
+    def nodelay(self, on: bool) -> None:
+        self.window.nodelay(1 if on else 0)
+
+    def update(self) -> None:
+        self.window.noutrefresh()
+
+
+class CursesLayout(WindowLayout):
     LOGGER_H = 25
     STATS_W = 25
     MAP_W = 30
 
     def __init__(self, screen, config_data: dict) -> None:
+        super().__init__(config_data=config_data)
+
         screen.nodelay(1)
-        self.config_data = config_data
         self.screen = screen
 
         self.logger = self._create_logger_window(screen=screen)
         # This sets up console and file logging
         initialize_logging(
-            game_name="Evoland", config_data=config_data, curses_win=self.logger
+            game_name="Evoland", config_data=config_data, curses_win=self.logger.window
         )
         self.main = self._create_main_window(screen=screen)
         self.stats = self._create_stats_window(screen=screen)
@@ -30,19 +76,12 @@ class WindowLayout:
         self._create_borders(screen=screen)
         screen.refresh()
 
-    def _create_logger_window(self, screen):
+    def _create_logger_window(self, screen) -> CursesWindow:
         # Determine the dimensions of the logger window
         maxy, maxx = screen.getmaxyx()
         begin_y, begin_x = maxy - self.LOGGER_H + 1, 1
         height, width = self.LOGGER_H - 2, maxx - 2
-        # Create curses window to hold the logger
-        logger_win = curses.newwin(height, width, begin_y, begin_x)
-        # Set parameters on window so that it scrolls automatically
-        logger_win.refresh()
-        logger_win.scrollok(True)
-        logger_win.idlok(True)
-        logger_win.leaveok(True)
-        return logger_win
+        return CursesWindow(Box2(pos=Vec2(begin_x, begin_y), w=width, h=height), auto_scroll=True)
 
     def _create_main_window(self, screen):
         # Determine the dimensions of the logger window
@@ -50,9 +89,7 @@ class WindowLayout:
         begin_y, begin_x = 1, 1
         height, width = maxy - self.LOGGER_H - 1, maxx - self.STATS_W - self.MAP_W - 4
         # Create curses window to hold the main data
-        main_win = curses.newwin(height, width, begin_y, begin_x)
-        main_win.refresh()
-        return main_win
+        return CursesWindow(Box2(pos=Vec2(begin_x, begin_y), w=width, h=height))
 
     def _create_stats_window(self, screen):
         # Determine the dimensions of the stats window
@@ -60,9 +97,7 @@ class WindowLayout:
         begin_y, begin_x = 1, maxx - self.STATS_W - self.MAP_W - 2
         height, width = maxy - self.LOGGER_H - 1, self.STATS_W
         # Create curses window to hold the gamestate data
-        stats_win = curses.newwin(height, width, begin_y, begin_x)
-        stats_win.refresh()
-        return stats_win
+        return CursesWindow(Box2(pos=Vec2(begin_x, begin_y), w=width, h=height))
 
     def _create_map_window(self, screen):
         # Determine the dimensions of the stats window
@@ -70,9 +105,7 @@ class WindowLayout:
         begin_y, begin_x = 1, maxx - self.MAP_W - 1
         height, width = maxy - self.LOGGER_H - 1, self.MAP_W
         # Create curses window to hold the gamestate data
-        map_win = curses.newwin(height, width, begin_y, begin_x)
-        map_win.refresh()
-        return map_win
+        return CursesWindow(Box2(pos=Vec2(begin_x, begin_y), w=width, h=height))
 
     def _create_borders(self, screen):
         maxy, maxx = screen.getmaxyx()
@@ -86,27 +119,14 @@ class WindowLayout:
         screen.move(1, maxx - self.MAP_W - 2)
         screen.vline(curses.ACS_VLINE, maxy - self.LOGGER_H - 1)
 
-    def write_stats_centered(self, line: int, text: str):
-        _, maxx = self.stats.getmaxyx()
-        text_len = len(text)
-        x_off = int(maxx / 2 - text_len / 2)
-        self.stats.addstr(line, x_off, text)
-
-    def write_map_centered(self, line: int, text: str):
-        _, maxx = self.map.getmaxyx()
-        text_len = len(text)
-        x_off = int(maxx / 2 - text_len / 2)
-        self.map.addstr(line, x_off, text)
-
     def update(self):
         # Update display windows
-        self.main.noutrefresh()
-        self.stats.noutrefresh()
-        self.map.noutrefresh()
+        self.main.update()
+        self.stats.update()
+        self.map.update()
         curses.doupdate()
 
 
 def setup_curses(screen, config_data: dict, func):
-    window = WindowLayout(screen, config_data=config_data)
-
+    window = CursesLayout(screen, config_data=config_data)
     func(window=window)

--- a/term/main_menu.py
+++ b/term/main_menu.py
@@ -3,7 +3,8 @@ import curses
 import evo1
 import evo2
 from app import TAS_VERSION_STRING
-from term.curses import WindowLayout
+from term.window import WindowLayout
+from engine.mathlib import Vec2
 
 from memory.seq_rng_observer import rng_observer
 
@@ -35,28 +36,27 @@ def main_menu(window: WindowLayout):
         ]
 
         # Update side window
-        window.stats.clear()
-        window.write_stats_centered(line=1, text="+ Evoland TAS +")
-        window.write_stats_centered(line=2, text=TAS_VERSION_STRING)
-        window.write_stats_centered(line=4, text="author:")
-        window.write_stats_centered(line=5, text="orkaboy")
-        window.stats.noutrefresh()
+        window.stats.erase()
+        window.stats.write_centered(line=1, text="+ Evoland TAS +")
+        window.stats.write_centered(line=2, text=TAS_VERSION_STRING)
+        window.stats.write_centered(line=4, text="author:")
+        window.stats.write_centered(line=5, text="orkaboy")
+        window.stats.update()
 
         # Update main window
-        window.main.clear()
+        window.main.erase()
         line = 1
         for opt in options:
             key = opt.get("key", "x")
             text = opt.get("name", "ERROR")
-            window.main.addstr(line, 1, f"({key}) {text}")
+            window.main.addstr(Vec2(1, line), f"({key}) {text}")
             line = line + 1
         line = line + 1
-        window.main.addstr(line, 1, "(q) Quit")
-        window.main.noutrefresh()
+        window.main.addstr(Vec2(1, line), "(q) Quit")
 
         # Update screen
-        curses.doupdate()
-        window.main.nodelay(0)
+        window.update()
+        window.main.nodelay(False)
 
         do_refresh = True
         # Get user input
@@ -70,7 +70,7 @@ def main_menu(window: WindowLayout):
                 key = opt.get("key", "x")
                 func = opt.get("func", None)
                 if c == ord(key) and func != None:
-                    window.main.nodelay(1)
+                    window.main.nodelay(True)
                     # Call subfunction
                     func(window=window)
                     # Break loop to refresh screen

--- a/term/main_menu.py
+++ b/term/main_menu.py
@@ -1,5 +1,3 @@
-import curses
-
 import evo1
 import evo2
 from app import TAS_VERSION_STRING

--- a/term/window.py
+++ b/term/window.py
@@ -1,0 +1,45 @@
+from engine.mathlib import Vec2
+
+class SubWindow:
+    def __init__(self) -> None:
+        pass
+
+    @property
+    def size(self) -> Vec2:
+        return Vec2(0, 0)
+
+    def getch(self) -> str:
+        return ""
+
+    def hline(self, pos: Vec2, character: str, length: int) -> None:
+        pass
+
+    def addch(self, pos: Vec2, text: str) -> None:
+        pass
+
+    def addstr(self, pos: Vec2, text: str) -> None:
+        pass
+
+    def write_centered(self, line: int, text: str) -> None:
+        pass
+
+    def nodelay(self, on: bool) -> None:
+        pass
+
+    def erase(self) -> None:
+        pass
+
+    def update(self) -> None:
+        pass
+
+
+class WindowLayout:
+    def __init__(self, config_data: dict) -> None:
+        self.config_data = config_data
+        self.main = SubWindow()
+        self.stats = SubWindow()
+        self.map = SubWindow()
+        self.logger = SubWindow()
+
+    def update(self) -> None:
+        pass


### PR DESCRIPTION
The Curses terminal backend was starting to spread out across the codebase; this would be bad if I want to switch to something else in the future (like rich/textual), and is general poor form. This PR makes an abstract base class for terminal window/subwindow handling, and pushes all curses specific stuff into it's own file.

A future backend change might require a few more changes since the API is shaped to look like that of Curses, but this probably still will make it less work to switch over.